### PR TITLE
chore(cd): add auto-publishing support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,5 +36,4 @@ jobs:
         run: dotnet build $SOLUTION --configuration $BUILD_CONFIG -p:Version=${{steps.set_version.outputs.version}} --no-restore
 
       - name: Publish
-        if: startsWith(github.ref, 'refs/heads/release')
         run: nuget push **\*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish package
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    env:
+      BUILD_CONFIG: "Release"
+      SOLUTION: "Knock.net.sln"
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set Version
+        id: set_version
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const noRef = context.ref.replace('refs/tags/', '')
+            const noPrefix = noRef.replace('v', '')
+            core.setOutput('version', noPrefix)
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v1.0.5
+
+      - name: Restore dependencies
+        run: nuget restore $SOLUTION
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.x
+
+      - name: Build
+        run: dotnet build $SOLUTION --configuration $BUILD_CONFIG -p:Version=${{steps.set_version.outputs.version}} --no-restore
+
+      - name: Publish
+        if: startsWith(github.ref, 'refs/heads/release')
+        run: nuget push **\*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}

--- a/Knock.net/Knock.net.csproj
+++ b/Knock.net/Knock.net.csproj
@@ -7,6 +7,7 @@
     <Copyright>Copyright © Knock</Copyright>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageId>Knock.net</PackageId>


### PR DESCRIPTION
Adds a `publish.yml` workflow to support auto building and publishing releases to nuget. 

[Followed this article](https://www.jamescroft.co.uk/how-to-build-publish-nuget-packages-with-github-actions/).