### PR TITLE
feat(kno-3770): add subscription endpoints support

### DIFF
--- a/Knock.net/Resources/Objects/AddSubscriptions.cs
+++ b/Knock.net/Resources/Objects/AddSubscriptions.cs
@@ -1,0 +1,20 @@
+﻿namespace Knock
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Params to add subscriptions to object
+    /// </summary>
+    public class AddSubscriptions : BaseOptions
+    {
+        [JsonProperty("recipients")]
+        public List<object> Recipients { get; set; }
+
+        /// <summary>
+        /// A dictionary of data to pass through
+        /// </summary>
+        [JsonProperty("properties")]
+        public Dictionary<string, object> Properties { get; set; }
+    }
+}

--- a/Knock.net/Resources/Objects/DeleteSubscriptions.cs
+++ b/Knock.net/Resources/Objects/DeleteSubscriptions.cs
@@ -1,0 +1,14 @@
+﻿namespace Knock
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Params to delete subscriptions
+    /// </summary>
+    public class DeleteSubscriptions : BaseOptions
+    {
+        [JsonProperty("recipients")]
+        public List<object> Recipients { get; set; }
+    }
+}

--- a/Knock.net/Resources/Objects/ObjectSubscription.cs
+++ b/Knock.net/Resources/Objects/ObjectSubscription.cs
@@ -1,0 +1,42 @@
+﻿namespace Knock
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Contains information about a Knock Object record.
+    /// </summary>
+    public class ObjectSubscription
+    {
+
+        /// <summary>
+        /// The object that the recipient is subscribed to
+        /// </summary>
+        [JsonProperty("object")]
+        public Object Object { get; set; }
+
+        /// <summary>
+        /// The object that the recipient is subscribed to
+        /// </summary>
+        [JsonProperty("recipient")]
+        public object Recipient { get; set; }
+
+        /// <summary>
+        /// The data associated
+        /// </summary>
+        [JsonProperty("properties")]
+        public Dictionary<string, object> Properties { get; set; }
+
+        /// <summary>
+        /// The inserted at timestamp of the subscription
+        /// </summary>
+        [JsonProperty("inserted_at")]
+        public string InsertedAt { get; set; }
+
+        /// <summary>
+        /// The updated date for this object (as an ISO8601 datetime string)
+        /// </summary>
+        [JsonProperty("updated_at")]
+        public string UpdatedAt { get; set; }
+    }
+}

--- a/Knock.net/Resources/Objects/ObjectsResource.cs
+++ b/Knock.net/Resources/Objects/ObjectsResource.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.Collections.ObjectModel;
 
 namespace Knock
 {
@@ -388,6 +389,91 @@ namespace Knock
             };
 
             return await Client.MakeAPIRequest<PreferenceSet>(request, cancellationToken);
+        }
+
+        /// <summary>
+        /// Returns paginated object subscriptions
+        /// </summary>
+        /// <param name="collection">Collection name.</param>
+        /// <param name="objectId">Object unique identifier.</param>
+        /// <param name="options">Options for pagination</param>
+        /// <returns>A paginated list of ObjectSunscription records.</returns>
+        public async Task<PaginatedResponse<ObjectSubscription>> ListSubscriptions(string collection, string objectId, Dictionary<string, object> options = null)
+        {
+            var request = new KnockRequest
+            {
+                Path = $"/objects/{collection}/{objectId}/subscriptions",
+                Method = HttpMethod.Get,
+                Options = options
+            };
+
+            return await Client.MakeAPIRequest<PaginatedResponse<ObjectSubscription>>(request);
+        }
+
+        /// <summary>
+        /// Returns paginated object subscriptions
+        /// </summary>
+        /// <param name="collection">Collection name.</param>
+        /// <param name="objectId">Object unique identifier.</param>
+        /// <param name="options">Options for pagination</param>
+        /// <returns>A paginated list of ObjectSunscription records.</returns>
+        public async Task<PaginatedResponse<ObjectSubscription>> GetSubscriptions(string collection, string objectId, Dictionary<string, object> options = null)
+        {
+            if (options != null)
+            {
+                options.Add("mode", "recipient");
+            } else
+            {
+                options = new Dictionary<string, object>();
+                options.Add("mode", "recipient");
+            };
+
+            var request = new KnockRequest
+            {
+                Path = $"/objects/{collection}/{objectId}/subscriptions",
+                Method = HttpMethod.Get,
+                Options = options
+            };
+
+            return await Client.MakeAPIRequest<PaginatedResponse<ObjectSubscription>>(request);
+        }
+
+        /// <summary>
+        /// Adds subscriptions to object for recipients
+        /// </summary>
+        /// <param name="collection">object collection</param>
+        /// <param name="objectId">object collection</param>
+        /// <param name="addSubscriptionsOptions">ObjectSubscription creation parameters</param>
+        /// <returns>List of created schedules</returns>
+        public async Task<List<ObjectSubscription>> AddSubscriptions(string collection, string objectId, AddSubscriptions addSubscriptionsOptions)
+        {
+            var request = new KnockRequest
+            {
+                Path = $"/objects/{collection}/{objectId}/subscriptions",
+                Method = HttpMethod.Post,
+                Options = addSubscriptionsOptions,
+            };
+
+            return await Client.MakeAPIRequest<List<ObjectSubscription>>(request);
+        }
+
+        /// <summary>
+        /// Deletes subscriptions for recipients
+        /// </summary>
+        /// <param name="collection">object collection</param>
+        /// <param name="objectId">object collection</param>
+        /// <param name="deleteSubscriptionOptions">ObjectSubscription deletion parameters</param>
+        /// <returns>List of created schedules</returns>
+        public async Task<List<ObjectSubscription>> DeleteSubscriptions(string collection, string objectId, DeleteSubscriptions deleteSubscriptionOptions)
+        {
+            var request = new KnockRequest
+            {
+                Path = $"/objects/{collection}/{objectId}/subscriptions",
+                Method = HttpMethod.Delete,
+                Options = deleteSubscriptionOptions,
+            };
+
+            return await Client.MakeAPIRequest<List<ObjectSubscription>>(request);
         }
 
         #endregion

--- a/Knock.net/Resources/Objects/ObjectsResource.cs
+++ b/Knock.net/Resources/Objects/ObjectsResource.cs
@@ -23,9 +23,27 @@ namespace Knock
         public const string DefaultPreferenceSetId = "default";
 
         /// <summary>
+        /// Returns a paginated list of objects in collection
+        /// </summary>
+        /// <param name="collection">Collection name.</param>
+        /// <param name="options">Pagination options.</param>
+        /// <returns>A Knock Object record.</returns>
+        public async Task<PaginatedResponse<Object>> List(string collection, Dictionary<string, object> options = null)
+        {
+            var request = new KnockRequest
+            {
+                Path = $"/objects/{collection}",
+                Method = HttpMethod.Get,
+                Options = options,
+            };
+
+            return await Client.MakeAPIRequest<PaginatedResponse<Object>>(request);
+        }
+
+        /// <summary>
         /// Returns an object in a collection.
         /// </summary>
-        /// <param name="collection">Object unique identifier.</param>
+        /// <param name="collection">Collection name.</param>
         /// <param name="objectId">Object unique identifier.</param>
         /// <param name="cancellationToken">
         /// An optional token to cancel the request.

--- a/Knock.net/Resources/Objects/ObjectsResource.cs
+++ b/Knock.net/Resources/Objects/ObjectsResource.cs
@@ -416,7 +416,7 @@ namespace Knock
         /// <param name="collection">Collection name.</param>
         /// <param name="objectId">Object unique identifier.</param>
         /// <param name="options">Options for pagination</param>
-        /// <returns>A paginated list of ObjectSunscription records.</returns>
+        /// <returns>A paginated list of object subscription records.</returns>
         public async Task<PaginatedResponse<ObjectSubscription>> GetSubscriptions(string collection, string objectId, Dictionary<string, object> options = null)
         {
             if (options != null)
@@ -444,7 +444,7 @@ namespace Knock
         /// <param name="collection">object collection</param>
         /// <param name="objectId">object collection</param>
         /// <param name="addSubscriptionsOptions">ObjectSubscription creation parameters</param>
-        /// <returns>List of created schedules</returns>
+        /// <returns>List of created subscriptions</returns>
         public async Task<List<ObjectSubscription>> AddSubscriptions(string collection, string objectId, AddSubscriptions addSubscriptionsOptions)
         {
             var request = new KnockRequest
@@ -463,7 +463,7 @@ namespace Knock
         /// <param name="collection">object collection</param>
         /// <param name="objectId">object collection</param>
         /// <param name="deleteSubscriptionOptions">ObjectSubscription deletion parameters</param>
-        /// <returns>List of created schedules</returns>
+        /// <returns>List of created subscriptions</returns>
         public async Task<List<ObjectSubscription>> DeleteSubscriptions(string collection, string objectId, DeleteSubscriptions deleteSubscriptionOptions)
         {
             var request = new KnockRequest

--- a/Knock.net/Resources/Users/UsersResource.cs
+++ b/Knock.net/Resources/Users/UsersResource.cs
@@ -37,12 +37,28 @@ namespace Knock
         /// <returns>A Knock User record.</returns>
         public async Task<User> Get(string userId, CancellationToken cancellationToken = default)
         {
-            var request = new KnockRequest {
+            var request = new KnockRequest
+            {
                 Path = $"/users/{userId}",
                 Method = HttpMethod.Get,
             };
 
             return await Client.MakeAPIRequest<User>(request, cancellationToken);
+        }
+
+        /// <summary>
+        /// Returns a paginated list of users
+        /// </summary>
+        /// <returns>Paginate list of users.</returns>
+        public async Task<PaginatedResponse<User>> List(Dictionary<string, object> options = null)
+        {
+            var request = new KnockRequest {
+                Path = $"/users",
+                Method = HttpMethod.Get,
+                Options = options
+            };
+
+            return await Client.MakeAPIRequest<PaginatedResponse<User>>(request);
         }
 
         /// <summary>


### PR DESCRIPTION
Adds support for subscription endpoints:
* Add subscriptions to objects
* Delete subscriptions
* List subscription for object
* Get subscriptions for object as recipient
* Get subscriptions for user

Also adds missing support for:
* List users for environment
* List objects by collection for environment