### PR TITLE
chore: raise exceptions for non-2xx status codes

### DIFF
--- a/Knock.net.sln
+++ b/Knock.net.sln
@@ -38,6 +38,6 @@ Global
 		$0.CSharpFormattingPolicy = $3
 		$3.scope = text/x-csharp
 		$0.StandardHeader = $4
-		version = 0.1.14
+		version = 0.2.0
 	EndGlobalSection
 EndGlobal

--- a/Knock.net/Knock.net.csproj
+++ b/Knock.net/Knock.net.csproj
@@ -25,8 +25,8 @@
     <PackOnBuild>true</PackOnBuild>
     <Summary>Knock.net is the official .NET client for the Knock API.</Summary>
     <Title>Knock.net</Title>
-    <ReleaseVersion>0.1.15</ReleaseVersion>
-    <PackageVersion>0.1.15</PackageVersion>
+    <ReleaseVersion>0.2.0</ReleaseVersion>
+    <PackageVersion>0.2.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Knock.net/KnockClient.cs
+++ b/Knock.net/KnockClient.cs
@@ -42,7 +42,7 @@
         /// <summary>
         /// Describes the .NET SDK version.
         /// </summary>
-        public static string SdkVersion => "0.1.0";
+        public static string SdkVersion => "0.2.0";
 
         /// <summary>
         /// Default timeout for HTTP requests.
@@ -143,10 +143,12 @@
             CancellationToken cancellationToken = default)
         {
             var response = await MakeRawAPIRequest(request, cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
 
             var reader = new StreamReader(
                 await response.Content.ReadAsStreamAsync().ConfigureAwait(false));
             var data = await reader.ReadToEndAsync().ConfigureAwait(false);
+
             return RequestUtilities.FromJson<T>(data);
         }
 

--- a/KnockTests/KnockTests.csproj
+++ b/KnockTests/KnockTests.csproj
@@ -7,7 +7,7 @@
     <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <ReleaseVersion>0.1.14</ReleaseVersion>
+    <ReleaseVersion>0.2.0</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added `response.EnsureSuccessStatusCode()` which will raise an exception for non OK successes ([docs](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpresponsemessage.ensuresuccessstatuscode?view=net-9.0#system-net-http-httpresponsemessage-ensuresuccessstatuscode))

Proposing releasing this as `0.2.0` as it's a breaking change 