### PR TITLE
fix: only add query params to GET requests

### DIFF
--- a/Knock.net.sln
+++ b/Knock.net.sln
@@ -38,6 +38,6 @@ Global
 		$0.CSharpFormattingPolicy = $3
 		$3.scope = text/x-csharp
 		$0.StandardHeader = $4
-		version = 0.2.0
+		version = 0.2.1
 	EndGlobalSection
 EndGlobal

--- a/Knock.net/Knock.net.csproj
+++ b/Knock.net/Knock.net.csproj
@@ -25,8 +25,8 @@
     <PackOnBuild>true</PackOnBuild>
     <Summary>Knock.net is the official .NET client for the Knock API.</Summary>
     <Title>Knock.net</Title>
-    <ReleaseVersion>0.2.0</ReleaseVersion>
-    <PackageVersion>0.2.0</PackageVersion>
+    <ReleaseVersion>0.2.1</ReleaseVersion>
+    <PackageVersion>0.2.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Knock.net/Knock.net.csproj
+++ b/Knock.net/Knock.net.csproj
@@ -20,8 +20,8 @@
     <SignAssembly>True</SignAssembly>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.1.0</VersionPrefix>
-    <Version>0.1.0</Version>
+    <VersionPrefix>0.2.1</VersionPrefix>
+    <Version>0.2.1</Version>
     <PackOnBuild>true</PackOnBuild>
     <Summary>Knock.net is the official .NET client for the Knock API.</Summary>
     <Title>Knock.net</Title>

--- a/Knock.net/KnockClient.cs
+++ b/Knock.net/KnockClient.cs
@@ -42,7 +42,7 @@
         /// <summary>
         /// Describes the .NET SDK version.
         /// </summary>
-        public static string SdkVersion => "0.2.0";
+        public static string SdkVersion => "0.2.1";
 
         /// <summary>
         /// Default timeout for HTTP requests.

--- a/Knock.net/KnockClient.cs
+++ b/Knock.net/KnockClient.cs
@@ -189,7 +189,7 @@
             builder.Append(ApiBaseURL);
             builder.Append(request.Path);
 
-            if (request.Method != HttpMethod.Post && options != null)
+            if (request.Method == HttpMethod.Get && options != null)
             {
                 var queryParameters = RequestUtilities.CreateQueryString(options);
                 if (queryParameters != null && queryParameters.Length > 0)


### PR DESCRIPTION
### Description

This SDK currently checks the HTTP method of a given request to see whether it should add the request `Options` as query parameters (as opposed to in the body of the request). Unfortunately, it's currently targeted at any endpoint that does not have a `POST` method rather than to only the relevant `GET` requests. This means we have some `PUT` requests (like updating user preferences) which are passing query parameters unnecessarily.